### PR TITLE
Improve error handling

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -13,6 +13,8 @@ def main():
         db_port=os.environ["PGPORT"],
         db_user=os.environ["PGUSER"],
         db_name=os.environ["PGNAME"],
+        bot_owner=os.environ.get("OWNER", 203285581004931072),
+        bot_devs=[int(id) for id in os.environ.get("DEVELOPERS", "766337842031886336").split(",")],
     )
 
     makubot_bot.run(token)

--- a/src/listeners.py
+++ b/src/listeners.py
@@ -61,8 +61,9 @@ class Listeners(discord.ext.commands.Cog):
                 caught_exception)
             logger.error(formatted_tb)
             await ctx.send("Something went wrong, sorry!")
-            await self.bot.makusu.send(
-                f"Something went wrong!\n```{formatted_tb}```")
+            await util.alert_devs(self.bot,
+                f"Something went wrong!\n```{formatted_tb}```",
+                alert_owner=True)
 
     @commands.Cog.listener()
     async def on_error(self, ctx, caught_exception):

--- a/src/picturecommands.py
+++ b/src/picturecommands.py
@@ -238,9 +238,10 @@ class PictureAdder(discord.ext.commands.Cog):
                 await status_message.edit(content=response)
             except discord.errors.NotFound:
                 pass
-            await self.bot.makusu.send(
-                "Something went wrong in image_suggestion"
-                f"\n```{formatted_tb}```")
+            await util.alert_devs(self.bot,
+                "Something went wrong in image_suggestion",
+                f"\n```{formatted_tb}```",
+                alert_owner=True)
 
     async def apply_image_approved(
             self, filepath, cmd, requestor, status_message, image_bytes):
@@ -395,8 +396,9 @@ you just need to add an image to it!"""
             except BaseException as e:
                 formatted_tb = util.get_formatted_traceback(e)
                 await status_message.edit(content="Something went wrong ;a;")
-                await self.bot.makusu.send(
-                    f"Something went wrong in addimage\n```{formatted_tb}```")
+                await util.alert_devs(self.bot,
+                    f"Something went wrong in addimage\n```{formatted_tb}```",
+                    alert_owner=True)
                 raise
             else:
                 await status_message.edit(content="Sent to Maku for approval!")

--- a/src/reminders.py
+++ b/src/reminders.py
@@ -269,7 +269,7 @@ class ReminderCommands(discord.ext.commands.Cog):
                 "Uhh there was a person but they're gone now but the reminder "
                 f"was {reminder['reminder_message']}")
         elif not reminder_channel and not reminder_user:
-            await self.bot.makusu.send(f"Couldn't find stuff for {reminder}")
+            await util.alert_devs(self.bot, f"Couldn't find stuff for {reminder}", alert_owner=True)
         else:
             await reminder_channel.send(
                 f"{reminder_user.mention}, you have a message from "

--- a/src/runbot.py
+++ b/src/runbot.py
@@ -46,12 +46,14 @@ class MakuBot(commands.Bot):
                  db_port=None,
                  db_user=None,
                  db_name=None,
+                 bot_owner=None,
+                 bot_devs=None,
                  ):
         commands.Bot.__init__(
             self,
             command_prefix=commands.when_mentioned,
             case_insensitive=True,
-            owner_id=203285581004931072,
+            owner_id=bot_owner,
             allowed_mentions=discord.AllowedMentions(
                 everyone=False,
                 roles=False,
@@ -65,6 +67,8 @@ class MakuBot(commands.Bot):
         logger.info("Bot entering setup")
         self.s3_bucket = s3_bucket
         self.makusu = None
+        self.dev_ids = []
+        self.dev_ids = bot_devs
         self.shared = {}
         self.temp_dir_pointer = tempfile.TemporaryDirectory()
         self.shared["temp_dir"] = Path(self.temp_dir_pointer.name)
@@ -135,7 +139,8 @@ class MakuBot(commands.Bot):
         self.makusu = await self.fetch_user(self.owner_id)
         logger.info(
             f"\n\n\nLogged in at {datetime.now()} as {self.user.name} "
-            f"with ID {self.user.id}\n\n\n"
+            f"with ID {self.user.id}\n"
+            f"Sending errors to owner {self.owner_id} and devs {self.dev_ids}\n\n\n"
         )
         await self.change_presence(activity=discord.Game(
             name=r"Nao is being tsun to me :<"))

--- a/src/util.py
+++ b/src/util.py
@@ -268,20 +268,51 @@ async def displaytxt(
             await block_message.edit(content=r"```Closed.```")
             current_index = None
 
-async def err_not_implemented(ctx):
+async def get_dev_users(bot, include_owner):
+    ids = bot.dev_ids
+    ids += [bot.owner_id] if include_owner else []
+    users = []
+    for user_id in ids:
+        user = await bot.fetch_user(user_id)
+        users.append(user)
+    return users
+
+async def alert_devs(bot, message, alert_owner=False):
+    devs = await get_dev_users(bot, alert_owner)
+    for dev in devs:
+        await dev.send(message)
+
+async def get_visible_names(users):
+    user_names = []
+    for user in users:
+        user_names.append(user.name+"#"+str(user.discriminator))
+    return user_names
+
+async def err_not_implemented(ctx, warn=True):
+    bot = ctx.bot
     embed = discord.Embed(
         title="Sorry!",
-        description=(f"This command or feature hasn't been implemented yet! "
-            f"Why not DM `queen tired#1745` and harass her about it?"
-            f"\n\n"
-            f"Make sure to include this text: "
-            f"```{ctx.data}```\n\n"
-            f"You can use the regular, prefixed version of this command "
-            f"until it's added.",
-        ),
+        description="This command or feature hasn't been implemented yet! "
+            "You can use the regular, prefixed version of this command "
+            "until it's added.",
         color=discord.Color.red()
     )
-    embed.set_footer(text="Please be nice! She's the only one migrating me " + \
-                    "to slash commands!"
-    )
+    embed.set_image(url="https://thumbs.gfycat.com/EssentialBrownFrenchbulldog-size_restricted.gif")
+    if warn:
+        warning = f"User {ctx.author.name}#{ctx.author.discriminator} (`{ctx.author.id}`) " \
+                  f"in {ctx.guild.name} (`{ctx.guild.id}`) channel {ctx.channel.name} (`{ctx.channel.id}`) " \
+                  f"tried to use a command that hasn't been implemented yet.\n" \
+                  f"Raw data:\n```json\n{ctx.data}\n```"
+        await alert_devs(bot, warning)
+        devs = await get_dev_users(bot, False)
+        dev_names = await get_visible_names(devs)
+        if len(dev_names) > 1:
+            dev_name_string = f"`{'`, `'.join(dev_names[:-1])}` and `{dev_names[-1]}`"
+        else:
+            dev_name_string = f"`{dev_names[0]}`"
+        embed.add_field(
+            name=NO_WIDTH_SPACE,
+            value=f"By the way - I let my (active) developer(s), {dev_name_string}, "
+            "know that you want this worked on!"
+        )
     await ctx.send(embed=embed, hidden=True)


### PR DESCRIPTION
This fixes #287, but also does a lot more cool stuff:
* Bot owner is no longer hardcoded. It's assigned by ENV var `OWNER`, and if not defined defaults to @stevenpitts.
* Adds an additional ENV var `DEVELOPERS`. It's a comma-separated string of User IDs.
* Now, when an error is thrown, a `DEVELOPER` is _always_ messaged, but the `OWNER` is _optionally_ messaged. This makes it so that in the "official" instance of Makubot, @stevenpitts is only messaged if it's something they're directly responsible for (read: they don't get DMed about slash-command errors).
* `err_not_implemented` has been updated to optionally DM anyone who is a `DEVELOPER` when it gets called. Developers get information about the user, channel, and guild where the unimplemented command got invoked. They also get the raw data of the interaction. The user is notified that the `DEVELOPER` has been messaged.
* `err_not_implemented` now contains an [adorable gif of Nao](https://gfycat.com/essentialbrownfrenchbulldog) asking the user to "promise they'll come back" because they'll "meet again" (try the command in the future! Makubot will have the command implemented one day).