### PR TITLE
ENV Vars for guilds, devs, owner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,8 @@ services:
             - PGUSER=${PGUSER}
             - PGNAME=${PGNAME}
             - PYTHONUNBUFFERED=1
+            - OWNER=${OWNER:-203285581004931072}
+            - DEVELOPERS=${DEVELOPERS:-766337842031886336}
+            - DEV_GUILDS=${DEV_GUILDS:-None}
         healthcheck:
             test: ["CMD-SHELL", "discordhealthcheck"]

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,10 +1,11 @@
 from . import runbot
 import os
 
-
 def main():
     token = os.environ["DISCORD_BOT_TOKEN"]
-
+    dev_id_string = os.environ["DEVELOPERS"].split(" ")
+    dev_ids = []
+    for id in dev_id_string: dev_ids.append(int(id))
     makubot_bot = runbot.MakuBot(
         s3_bucket=os.environ.get("S3_BUCKET", None),
         google_api_key=os.environ.get("GOOGLE_API_KEY", None),
@@ -13,10 +14,9 @@ def main():
         db_port=os.environ["PGPORT"],
         db_user=os.environ["PGUSER"],
         db_name=os.environ["PGNAME"],
-        bot_owner=os.environ.get("OWNER", 203285581004931072),
-        bot_devs=[int(id) for id in os.environ.get("DEVELOPERS", "766337842031886336").split(",")],
+        bot_owner=int(os.environ["OWNER"]),
+        bot_devs=dev_ids,
     )
-
     makubot_bot.run(token)
 
 

--- a/src/picturecommands.py
+++ b/src/picturecommands.py
@@ -62,6 +62,8 @@ from .picturecommands_utils import (
     remove_denylist_association,
 )
 
+DEV_GUILDS = util.get_dev_guilds()
+
 logger = logging.getLogger()
 
 S3 = boto3.client("s3")
@@ -691,7 +693,7 @@ class ReactionImages(discord.ext.commands.Cog):
         )
     ]
 
-    @cog_ext.cog_slash(name="mb", description="Modify or see information about my commands!", options=__super_utils_options, guild_ids=[669939748529504267])
+    @cog_ext.cog_slash(name="mb", description="Modify or see information about my commands!", options=__super_utils_options, guild_ids=DEV_GUILDS)
     async def super_image_utils(self, ctx, image_util: str, input_args: Optional[str] = None):
         async def my_commands(ctx):
             cmds = get_all_user_cmds(self.bot.db_connection, ctx.author_id)

--- a/src/runbot.py
+++ b/src/runbot.py
@@ -36,7 +36,6 @@ def get_intents():
     intents.members = False
     return intents
 
-
 class MakuBot(commands.Bot):
     def __init__(self,
                  s3_bucket=None,
@@ -99,7 +98,6 @@ class MakuBot(commands.Bot):
         self.db_user = db_user
         self.db_name = db_name
         self.loop.set_debug(True)
-
         logger.info(
             f"Attempting to connect to postgres database at {self.db_host} "
             f"on port {self.db_port} as user {self.db_user} "
@@ -140,7 +138,8 @@ class MakuBot(commands.Bot):
         logger.info(
             f"\n\n\nLogged in at {datetime.now()} as {self.user.name} "
             f"with ID {self.user.id}\n"
-            f"Sending errors to owner {self.owner_id} and devs {self.dev_ids}\n\n\n"
+            f"Sending errors to owner {self.owner_id} and devs {self.dev_ids}."
+            f"\nBeta access available in test servers {util.get_dev_guilds()}\n\n\n"
         )
         await self.change_presence(activity=discord.Game(
             name=r"Nao is being tsun to me :<"))

--- a/src/util.py
+++ b/src/util.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 import traceback
 import logging
 from datetime import datetime
@@ -316,3 +317,13 @@ async def err_not_implemented(ctx, warn=True):
             "know that you want this worked on!"
         )
     await ctx.send(embed=embed, hidden=True)
+
+def get_dev_guilds():
+    envvar = os.environ.get("DEV_GUILDS")
+    if envvar is None or envvar == "":
+        return None
+    else:
+        dev_guilds = []
+        for id in envvar.split(" "):
+            dev_guilds.append(int(id))
+        return dev_guilds


### PR DESCRIPTION
Fixes an issue in the previous commit where env vars weren't actually getting read. Additionally adds the `DEV_GUILDS` var, which allows us to beta test new commands in certain servers before widely releasing them.